### PR TITLE
Improve CP/M disk image creation

### DIFF
--- a/doc/DiskImage-CPM22-ja.md
+++ b/doc/DiskImage-CPM22-ja.md
@@ -1,0 +1,73 @@
+# CP/M DISK Imageの作成方法
+
+## 概要
+本システムでは、CP/MのディスクをmicroSD Cardでエミュレーションしている。ディスクイメージはmicroSD Card上のファイルとして管理されるため、複数のイメージファイルを置いておけば、それらは独立したディスクドライブとみなすことができる。
+
+microSD Cardは**FAT32**でフォーマットされていること。
+
+ディスクイメージファイルの命名規則
+  - DISKnn.IMG (nnは00-15で、ドライブA:-P:に対応する)
+
+ドライブA:であるDISK00.IMGはCP/Mのシステム(CCP+BDOS)を含む必要がある。メモリの関係上、BIOSでは５ドライブまでしかサポートしていない。したがって実際に使えるのは00-04までである。
+
+
+ディスクイメージは、BIOSでサポートするDPBに合致したものでなければならない。BIOSは、cpmtoolsのフォーマット定義`/etc/cpmtools/diskdefs`のうち、`sdcard`を採用している。
+```
+diskdef sdcard
+seclen 512
+tracks 256
+sectrk 64
+blocksize 8192
+maxdir 256
+skew 0
+boottrk 1
+os 2.2
+end
+```
+
+このフォーマットではboottrkで1トラックが予約されており、システムディスク(`IMAGE00.IMG`)では、CP/Mのシステム(CCP+BDOS)がここに格納される。
+
+
+ATmega128側のファームウェアで利用しているSD Cardのアクセスライブラリは、すでに存在するファイルに対してしか書き込み操作ができない。このためイメージファイルは全データ(約8GB)が事前に生成されている必要がある。
+
+## ディスクイメージファイルの生成方法
+`z80/cpm22/image/Makefile`では以下のイメージ生成をサポートしている。
+
+### CP/M2.2 システムディスク
+[CP/M 2.2 BINARY](http://www.cpm.z80.de/download/cpm22-b.zip)
+をベースに`DISK00.IMG`を生成する。
+```
+make
+```
+
+### 空のディスクイメージ
+`EMPTY.IMG`が生成されるので、`DISKnn.IMG`にコピーして使用するか、これをベースに新たなイメージを作成する。
+```
+make empty
+```
+
+### ZORK I/II/III
+```
+make zork
+```
+`ZORK.IMG`が生成されるので、`DISKnn.IMG`にコピーして使用する。
+
+### 任意のディスクイメージ
+cpmtoolsの`cpm.cp`を使用し、任意のファイルをディスクイメージ上に転送することで、任意のイメージを作成できる。
+
+例えば[CP/M software Download site](#cpm-software-download-site)などにはたくさんのCP/Mのバイナリファイルが存在する。その中から必要なファイルをピックアップしてディスクイメージを作成することもできる。
+
+
+以下の例では、`./tmp`の全ファイルを空のディスクイメージに転送し、`DISK01.IMG`として`B:`ドライブに割り当てる。
+```
+cpmcp -f sdcard EMPTY.IMG ./tmp/*.* 0:
+cp EMPTY.IMG DISK01.IMG
+```
+
+## CP/M software Download site
+- [The Unofficial CP/M Web site](http://www.cpm.z80.de/)
+  - [CP/M binary](http://www.cpm.z80.de/binary.html)
+  - [CP/M source](http://www.cpm.z80.de/source.html)
+- [Commercial CP/M Software](http://www.retroarchive.org/cpm/)
+  - [ZORK I/II/III](http://www.retroarchive.org/cpm/games/zork123_80.zip)
+  - 

--- a/doc/DiskImage-CPM22-ja.md
+++ b/doc/DiskImage-CPM22-ja.md
@@ -39,6 +39,12 @@ ATmega128側のファームウェアで利用しているSD Cardのアクセス�
 ```
 make
 ```
+#### `z80/cpm22/sys/CPM.SYS`を使用する場合
+[CP/M 2.2 ASM SOURCE](http://www.cpm.z80.de/download/cpm2-asm.zip)のソースコードをベースに構築した`CPM.SYS`を使用する場合、`z80/cpm22/image/Makefile`を以下のように変更する。
+```
+CCPBDOS   = ../sys/CPM.SYS
+#CCPBDOS  = $(CPM22_DIR)/CPM.SYS
+```
 
 ### 空のディスクイメージ
 `EMPTY.IMG`が生成されるので、`DISKnn.IMG`にコピーして使用するか、これをベースに新たなイメージを作成する。

--- a/doc/DiskImage-CPM22.md
+++ b/doc/DiskImage-CPM22.md
@@ -36,6 +36,12 @@ Generate `DISK00.IMG` based on [CP/M 2.2 BINARY](http://www.cpm.z80.de/download/
 ```
 make
 ```
+#### When using `z80/cpm22/sys/CPM.SYS`
+If you want to use `CPM.SYS` built based on the source code of [CP/M 2.2 ASM SOURCE](http://www.cpm.z80.de/download/cpm2-asm.zip), change `z80/cpm22/image/Makefile` as follows.
+```
+CCPBDOS   = ../sys/CPM.SYS
+#CCPBDOS  = $(CPM22_DIR)/CPM.SYS
+```
 
 ### Empty disk image
 `EMPTY.IMG` will be generated, so copy it to `DISKnn.IMG` and use it, or create a new image based on this.

--- a/doc/DiskImage-CPM22.md
+++ b/doc/DiskImage-CPM22.md
@@ -1,0 +1,69 @@
+# How to make CP/M DISK Image
+
+## Overview
+This system emulates a CP/M disk on a microSD Card. Disk images are managed as files on the microSD Card, so if multiple image files are in it, they are considered independent disk drives.
+
+The microSD Card must be formatted with **FAT32**.
+
+Disk image file naming conventions
+  - `DISKnn.IMG` (`nn` is 00-15, corresponding to drives A:-P:)
+
+`DISK00.IMG`, which is drive A: must contain the CP/M system (CCP+BDOS). Due to memory limitations, the BIOS on this system only supports up to 5 drives. Therefore, the actual usable drives are up to 00-04.
+
+The disk image must match the DPB supported by the BIOS. The BIOS uses `sdcard` from the cpmtools format definition `/etc/cpmtools/diskdefs`.
+```
+diskdef sdcard
+seclen 512
+tracks 256
+sectrk 64
+blocksize 8192
+maxdir 256
+skew 0
+boottrk 1
+os 2.2
+end
+```
+
+In this format, one track is reserved for boottrk, and the CP/M system (CCP+BDOS) is stored here on the system disk (`IMAGE00.IMG`).
+
+The SD Card access library in ATmega128 firmware can only write to files that already exist. For this limitation, all data (approximately 8GB) of the disk image file must be generated in advance.
+
+## How to generate a disk image file
+`z80/cpm22/image/Makefile` supports the following image generation.
+
+### CP/M2.2 system disk
+Generate `DISK00.IMG` based on [CP/M 2.2 BINARY](http://www.cpm.z80.de/download/cpm22-b.zip).
+```
+make
+```
+
+### Empty disk image
+`EMPTY.IMG` will be generated, so copy it to `DISKnn.IMG` and use it, or create a new image based on this.
+```
+make empty
+```
+
+### ZORK I/II/III
+```
+make zork
+```
+`ZORK.IMG` will be generated, so copy it to `DISKnn.IMG` and use it.
+
+### Any disk image
+You can create any image by using cpmtools' `cpm.cp' to transfer any file onto the disk image.
+
+For example, there are many CP/M binary files at [CP/M software Download site](#cpm-software-download-site). You can also pick up the files and create a disk image that you want.
+
+The following example transfers all files in `./tmp` to an empty disk image and assigns it to the `B:` drive as `DISK01.IMG`.
+```
+cpmcp -f sdcard EMPTY.IMG ./tmp/*.* 0:
+cp EMPTY.IMG DISK01.IMG
+```
+
+## CP/M software Download site
+- [The Unofficial CP/M Web site](http://www.cpm.z80.de/)
+  - [CP/M binary](http://www.cpm.z80.de/binary.html)
+  - [CP/M source](http://www.cpm.z80.de/source.html)
+- [Commercial CP/M Software](http://www.retroarchive.org/cpm/)
+  - [ZORK I/II/III](http://www.retroarchive.org/cpm/games/zork123_80.zip)
+  - 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,7 @@
 # Documents
 ## User's Guide
 - Z80ATmega128 Board Setup Guide ([English](./SetupGuide_en.md) / [Japanese](./SetupGuide.md))
+- How to make CP/M2.2 disk image ([English](./DiskImage-CPM22.md) / [Japanese](./DiskImage-CPM22-ja.md))
 - [ATmega128 Tiny Monitor Command Reference](./Software/AVRTinyMonitor.md)
 
 ## Hardware Specifications

--- a/z80/cpm22/image/Makefile
+++ b/z80/cpm22/image/Makefile
@@ -1,13 +1,12 @@
-#
+##########################################################
 # Create CP/M DISK Image
 #
 # cpmtool is required.
-#
+##########################################################
 RM		:= rm
 CP		:= cp
 MKDIR	:= mkdir
 MAKE	:= make
-
 WGET	:= wget
 UNZIP	:= unzip
 DD		:= dd
@@ -19,34 +18,90 @@ CPM_CP		:= cpmcp
 CPM_LS		:= cpmls
 
 # DISK configuration. See /etc/cpmtools/diskdefs
-DISKDEF	= sdcard
+DISKDEF		:= sdcard
+USER		:= 0:
+TMPDIR		:= ./tmp
 
+##########################################################
+# CP/M2.2 image
+#    make
+#
+# Copy IMAGE00.IMG to SD Card.
+##########################################################
 # CCP+BDOS binary for embedding to the DISK image
 #CCPBDOS = ../sys/CPM.SYS
-CCPBDOS = $(TMPDIR)/CPM.SYS
-
-USER	= 0:
-IMAGE   = DISK00.IMG
-TMPDIR	= ./tmp
+CCPBDOS		= $(CPM22_DIR)/CPM.SYS
+CPM22_IMAGE	= DISK00.IMG
+CPM22_DIR	= $(TMPDIR)/cpm22
 
 # Create DISK image of CP/M 2.2 for SD card using cpmtools
 #   CCP+BDOS speficied by $(CCPBDOS) is set to reserved track. 
-#   Files are copy from $(TMPDIR).
-$(IMAGE):	$(TMPDIR)
+#   Files are copy from $(CPM22_IMAGE).
+$(CPM22_IMAGE):	$(CPM22_DIR)
 	$(CPM_MKFS) -f $(DISKDEF) -b $(CCPBDOS) $@
 	$(DD) if=/dev/zero of=$@ bs=8192 count=1021 oflag=append conv=notrunc
-	$(CPM_CP) -f $(DISKDEF) $@ $(TMPDIR)/*.* $(USER)
+	$(CPM_CP) -f $(DISKDEF) $@ $(CPM22_DIR)/*.* $(USER)
 	$(CPM_LS) -f $(DISKDEF) $@
 	echo `wc -c < $@`
 
 # Download CP/M 2.2 binay:
 #   http://www.cpm.z80.de/download/cpm22-b.zip
-$(TMPDIR):
-	$(MKDIR) -p $(TMPDIR)
-	$(WGET) -P $(TMPDIR) http://www.cpm.z80.de/download/cpm22-b.zip
-	$(UNZIP) -o -d $(TMPDIR) $(TMPDIR)/cpm22-b.zip
-	$(RM) -f $(TMPDIR)/cpm22-b.zip
+$(CPM22_DIR):
+	$(MKDIR) -p $(CPM22_DIR)
+	$(WGET) -P $(CPM22_DIR) http://www.cpm.z80.de/download/cpm22-b.zip
+	$(UNZIP) -o -d $(CPM22_DIR) $(CPM22_DIR)/cpm22-b.zip
 
+##########################################################
+# Empty disk image
+#    make empty
+#
+# Rename EMPTY.IMG with IMAGEnn.IMG and copy it to SD Card.
+# (nn is 00 to 04)
+##########################################################
+EMPTY_IMAGE	= EMPTY.IMG
+
+.PHONY: empty
+empty:	$(EMPTY_IMAGE)
+
+$(EMPTY_IMAGE):
+	$(CPM_MKFS) -f $(DISKDEF) $@
+	$(DD) if=/dev/zero of=$@ bs=8192 count=1021 oflag=append conv=notrunc
+	$(CPM_LS) -f $(DISKDEF) $@
+	echo `wc -c < $@`
+
+##########################################################
+# ZORK I/II/III image
+#    make zork
+#
+# Rename ZORK.IMG with IMAGEnn.IMG and copy it to SD Card.
+# (nn is 00 to 04)
+##########################################################
+ZORK_IMAGE	= ZORK.IMG
+ZORK_DIR = $(TMPDIR)/zork
+
+.PHONY: zork
+zork:	$(ZORK_IMAGE)
+
+# Create DISK image of ZORK I/II/III
+$(ZORK_IMAGE):	$(ZORK_DIR)
+	$(CPM_MKFS) -f $(DISKDEF) $@
+	$(DD) if=/dev/zero of=$@ bs=8192 count=1021 oflag=append conv=notrunc
+	$(CPM_CP) -f $(DISKDEF) $@ $(ZORK_DIR)/*.* $(USER)
+	$(CPM_LS) -f $(DISKDEF) $@
+	echo `wc -c < $@`
+
+# Download ZORK I/II/III
+$(ZORK_DIR):
+	$(MKDIR) -p $(ZORK_DIR)
+	$(WGET) -P $(ZORK_DIR) http://www.retroarchive.org/cpm/games/zork123_80.zip
+	$(UNZIP) -o -d $(ZORK_DIR) $(ZORK_DIR)/zork123_80.zip
+
+
+##########################################################
+# Utilities
+#    make ls|dump IMAGE=<image file>
+#    make clean
+##########################################################
 # list files in the image file
 .PHONY: ls
 ls:
@@ -60,5 +115,5 @@ dump:
 # clean up
 .PHONY: clean
 clean:
-	@$(RM) -f $(IMAGE)
+	@$(RM) -f *.IMG *.img
 	@$(RM) -fr $(TMPDIR)


### PR DESCRIPTION
Support image creation on Makefile:
- CP/M 2.2 system disk
- An empty disk
- ZORK I/II/III

Add a document on how to make CP/M disk image.
