### PR TITLE
fix #13

### DIFF
--- a/doc/Diary4.md
+++ b/doc/Diary4.md
@@ -1,4 +1,18 @@
 ## [以前の日記](Diary3.md)
 
-## 20204/1/15
+## 2024/1/15
 些細なドキュメントのバグを修正。
+
+## 2024/1/21
+CP/MのDISKイメージを操作する[cpmtools](http://www.moria.de/~michael/cpmtools/)、DISKのフォーマットが`/etc/cpmtools/diskdefs`に定義されているものしか指定できず不便。ドキュメントを読んでも任意の`diskdefs`を指定する方法がなさそうなので、いっちょ修正してやろうかとソースを読み始めた。
+
+cpmfs.c
+```
+  if ((fp=fopen("diskdefs","r"))==(FILE*)0 && (fp=fopen(DISKDEFS,"r"))==(FILE*)0)
+  {
+    fprintf(stderr,"%s: Neither `diskdefs' nor `" DISKDEFS "' could be opened.\n",cmd);
+    exit(1);
+  }
+```
+なんだ、カレントディレクトリに自分好みの`diskdefs`を置いとけばいいのか...。  
+ということで、[Issue#13](https://github.com/46nori/Z80Atmega128/issues/13)を修正した。

--- a/doc/DiskImage-CPM22-ja.md
+++ b/doc/DiskImage-CPM22-ja.md
@@ -10,8 +10,7 @@ microSD Cardは**FAT32**でフォーマットされていること。
 
 ドライブA:であるDISK00.IMGはCP/Mのシステム(CCP+BDOS)を含む必要がある。メモリの関係上、BIOSでは５ドライブまでしかサポートしていない。したがって実際に使えるのは00-04までである。
 
-
-ディスクイメージは、BIOSでサポートするDPBに合致したものでなければならない。BIOSは、cpmtoolsのフォーマット定義`/etc/cpmtools/diskdefs`のうち、`sdcard`を採用している。
+ディスクイメージは、BIOSのDPBの形式に合致していなければならない。cpmtoolsでディスクイメージを生成する際には`diskdefs`で定義した以下のフォーマットを指定する。
 ```
 diskdef sdcard
 seclen 512

--- a/doc/DiskImage-CPM22.md
+++ b/doc/DiskImage-CPM22.md
@@ -10,7 +10,7 @@ Disk image file naming conventions
 
 `DISK00.IMG`, which is drive A: must contain the CP/M system (CCP+BDOS). Due to memory limitations, the BIOS on this system only supports up to 5 drives. Therefore, the actual usable drives are up to 00-04.
 
-The disk image must match the DPB supported by the BIOS. The BIOS uses `sdcard` from the cpmtools format definition `/etc/cpmtools/diskdefs`.
+The disk image must match the DPB supported by the BIOS. When generating a disk image with cpmtools, specify the following format defined in `diskdefs`.
 ```
 diskdef sdcard
 seclen 512

--- a/doc/SetupGuide.md
+++ b/doc/SetupGuide.md
@@ -135,19 +135,6 @@ WindowsはWSL、macOSはVS Code + Dev Containerの環境がおすすめ。
    ```
    sudo apt-get install -y cpmtools
    ```
-   `/etc/cpmtools/diskdefs`に以下の定義がない場合は追加する。([Issue#13](https://github.com/46nori/Z80Atmega128/issues/13))
-   ```
-   diskdef sdcard
-     seclen 512
-     tracks 256
-     sectrk 64
-     blocksize 8192
-     maxdir 256
-     skew 0
-     boottrk 1
-     os 2.2
-   end
-   ```
 
 #### VS Code + Dev Containerの場合
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) と [VS Code](https://azure.microsoft.com/ja-jp/products/visual-studio-code/)をインストール

--- a/doc/SetupGuide_en.md
+++ b/doc/SetupGuide_en.md
@@ -136,20 +136,6 @@ WSL for Windows and VS Code + Dev Container environment for macOS are recommende
    ```
    sudo apt-get install -y cpmtools
    ```
-   In some environments, the following definitions may not be in `/etc/cpmtools/diskdefs`. In that case, add them. ([Issue#13](https://github.com/46nori/Z80Atmega128/issues/13))
-   ```
-   diskdef sdcard
-     seclen 512
-     tracks 256
-     sectrk 64
-     blocksize 8192
-     maxdir 256
-     skew 0
-     boottrk 1
-     os 2.2
-   end
-   ```
-
 
 #### VS Code + Dev Container
 - Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)

--- a/z80/cpm22/image/Makefile
+++ b/z80/cpm22/image/Makefile
@@ -18,7 +18,7 @@ CPM_CP		:= cpmcp
 CPM_LS		:= cpmls
 
 # DISK configuration. See /etc/cpmtools/diskdefs
-DISKDEF		:= hoge
+DISKDEF		:= sdcard
 USER		:= 0:
 TMPDIR		:= ./tmp
 

--- a/z80/cpm22/image/Makefile
+++ b/z80/cpm22/image/Makefile
@@ -18,7 +18,7 @@ CPM_CP		:= cpmcp
 CPM_LS		:= cpmls
 
 # DISK configuration. See /etc/cpmtools/diskdefs
-DISKDEF		:= sdcard
+DISKDEF		:= hoge
 USER		:= 0:
 TMPDIR		:= ./tmp
 

--- a/z80/cpm22/image/diskdefs
+++ b/z80/cpm22/image/diskdefs
@@ -1,0 +1,10 @@
+diskdef sdcard
+  seclen 512
+  tracks 256
+  sectrk 64
+  blocksize 8192
+  maxdir 256
+  skew 0
+  boottrk 1
+  os 2.2
+end

--- a/z80/cpm3/image/diskdefs
+++ b/z80/cpm3/image/diskdefs
@@ -1,0 +1,10 @@
+diskdef sdcard
+  seclen 512
+  tracks 256
+  sectrk 64
+  blocksize 8192
+  maxdir 256
+  skew 0
+  boottrk 1
+  os 2.2
+end


### PR DESCRIPTION
Added local `diskdefs` file to the directory where cpmtools is run. This will be used instead of the default one (`/etc/cpmtools/diskdefs`).