### PR TITLE
BUG #4 [MODERATE]: x_enqueue()/x_dequeue()/x_flush() の SREG 保存/復元

### DIFF
--- a/avr/src/xconsoleio.c
+++ b/avr/src/xconsoleio.c
@@ -133,11 +133,12 @@ void initConsoleBuffer(ConsoleBuffer* cb, char* buffer, int size)
 
 void x_flush(ConsoleBuffer* cb)
 {
+	uint8_t sreg = SREG;
 	cli();
 	cb->head = 0;
 	cb->tail = 0;
 	cb->count = 0;
-	sei();
+	SREG = sreg;
 }
 
 int x_enqueue(ConsoleBuffer* cb, char data)
@@ -146,11 +147,12 @@ int x_enqueue(ConsoleBuffer* cb, char data)
 		return 3;	// Buffer is already full. Cannot enqueue.
 	}
 
+	uint8_t sreg = SREG;
 	cli();
 	cb->buffer[cb->tail] = data;
 	cb->tail = (cb->tail + 1) % cb->size;
 	cb->count++;
-	sei();
+	SREG = sreg;
 	if (cb->count == cb->size / 2) {
 		return 1;	// Buffer is half full.
 	}
@@ -166,11 +168,12 @@ char x_dequeue(ConsoleBuffer* cb)
 		return '\0';  // Buffer is empty. Cannot dequeue.
 	}
 
+	uint8_t sreg = SREG;
 	cli();
 	char data = cb->buffer[cb->head];
 	cb->head = (cb->head + 1) % cb->size;
 	cb->count--;
-	sei();
+	SREG = sreg;
 	return data;
 }
 


### PR DESCRIPTION
# BUG #4: `x_enqueue()`/`x_dequeue()` の ISR 内 `sei()` 問題

## 重大度: MODERATE

## 問題
`xconsoleio.c` の `x_enqueue()`、`x_dequeue()`、`x_flush()` で使用されている `cli()`/`sei()` パターンが、ISR コンテキストから呼ばれた場合に問題を引き起こす。`sei()` が無条件に割り込みを再有効化するため、ISR 完了前に他の割り込みがプリエンプトし、PR #30 のレースコンディション窓を拡大する。

## 修正内容
`cli()`/`sei()` を `SREG` 保存/復元パターンに変更し、呼び出し元の割り込み状態を破壊しないようにした。

```c
// Before
cli();
// critical section
sei();

// After
uint8_t sreg = SREG;
cli();
// critical section
SREG = sreg;
```

## 対象関数
- `x_flush()`
- `x_enqueue()`
- `x_dequeue()`

## 影響
- #30 のレース発生確率を低減
- 通常コンテキストからの呼び出しでは動作に変化なし（SREG 復元は事実上 `sei()` と同等）

## Phase 1 / Step 1

Ref: BugFixPlan.md