### PR TITLE
BUG #11 [MODERATE]: IN_0E_DSK_WriteStatus()/IN_13_DSK_ReadStatus() の SREG 保存/復元

### DIFF
--- a/avr/src/emuldev/em_diskio.c
+++ b/avr/src/emuldev/em_diskio.c
@@ -202,6 +202,7 @@ TEMPLATE_IN_OUT_2BYTES(12,DSK_ReadLen)
 uint8_t IN_0E_DSK_WriteStatus()
 {
 	// CAUTION: don't consume long time
+	uint8_t sreg = SREG;
 	cli();
 	uint8_t st = 0x00;
 	switch (cfd->write.state) {
@@ -218,7 +219,7 @@ uint8_t IN_0E_DSK_WriteStatus()
 			st = 0x04;			// rejected
 			break;
 	}
-	sei();
+	SREG = sreg;
 	return st;
 }
 
@@ -468,6 +469,7 @@ error_skip:
 uint8_t IN_13_DSK_ReadStatus()
 {
 	// CAUTION: don't consume long time
+	uint8_t sreg = SREG;
 	cli();
 	uint8_t st = 0x00;
 	switch (cfd->read.state) {
@@ -484,7 +486,7 @@ uint8_t IN_13_DSK_ReadStatus()
 		st = 0x04;			// rejected
 		break;
 	}
-	sei();
+	SREG = sreg;
 	return st;
 }
 


### PR DESCRIPTION
# BUG #11: `IN_0E_DSK_WriteStatus()`/`IN_13_DSK_ReadStatus()` の `sei()` 問題

## 重大度: MODERATE

## 問題
`IN_0E_DSK_WriteStatus()` と `IN_13_DSK_ReadStatus()` は INT0 ISR（Z80 IN 命令ハンドラ）から呼ばれる。INT0 ISR は通常 ISR（割り込み無効）であるため、内部の `cli()`/`sei()` は不要であり、かつ `sei()` が ISR 完了前に割り込みを再有効化する。#19 と同じパターン。

## 修正内容
`cli()`/`sei()` を `SREG` 保存/復元パターンに変更。

## 対象関数
- `IN_0E_DSK_WriteStatus()`
- `IN_13_DSK_ReadStatus()`

## 影響\n- INT0 ISR 内での予期しない割り込み再有効化を防止\n- BUG #1 のレース窓を間接的に縮小

## Phase 1 / Step 2

Ref: BugFixPlan.md