### PR TITLE
BUG #10 [MODERATE]: int_level_write/int_level_read に volatile を追加

### DIFF
--- a/avr/src/emuldev/em_diskio.c
+++ b/avr/src/emuldev/em_diskio.c
@@ -23,8 +23,8 @@
 // DISK I/O emulated device
 //=================================================================
 // Disk parameters
-static uint8_t int_level_write = 128;
-static uint8_t int_level_read  = 128;
+static volatile uint8_t int_level_write = 128;
+static volatile uint8_t int_level_read  = 128;
 
 static uint8_t tmpbuf[512];
 


### PR DESCRIPTION
# BUG #10: `int_level_write`/`int_level_read` に `volatile` がない

## 重大度: MODERATE

## 問題
`int_level_write` と `int_level_read` は INT1 コンテキスト（OUT ハンドラ）で書き込まれ、Timer2 コンテキスト（`em_disk_read()`/`em_disk_write()`）で読み込まれる。`volatile` がないためコンパイラ最適化でレジスタキャッシュされるリスクがある。\n\n同ファイル内の `em_consoleio.c` では `z80_int_num_rx1`/`z80_int_num_tx1` が `volatile` 宣言されており、非対称であった。

## 修正内容
```c
// Before
static uint8_t int_level_write = 128;
static uint8_t int_level_read  = 128;

// After
static volatile uint8_t int_level_write = 128;
static volatile uint8_t int_level_read  = 128;
```

## 影響
- コンパイラ最適化条件下での割り込み通知欠落を防止
 
## Phase 1 / Step 3

Ref: BugFixPlan.md