### PR TITLE
BUG #13 [MODERATE]: ConsoleBuffer の head/tail/count に volatile を追加

### DIFF
--- a/avr/src/xconsoleio.h
+++ b/avr/src/xconsoleio.h
@@ -15,9 +15,9 @@
 typedef struct {
 	char* buffer;
 	int size;
-	int head;
-	int tail;
-	int count;
+	volatile int head;
+	volatile int tail;
+	volatile int count;
 } ConsoleBuffer;
 
 extern void initConsoleBuffer(ConsoleBuffer* cb, char* buffer, int size);


### PR DESCRIPTION
# BUG #13: `ConsoleBuffer` の `count`/`head`/`tail` に `volatile` がない

## 重大度: MODERATE

## 問題
`cb_rx1` は USART1_RX ISR（`Enqueue_RX1_Buf` → `x_enqueue`）と INT0 ISR（`IN_00_CONIN` → `x_dequeue`、`IN_01_CONIN_GetStatus` → `count` 直読み）の複数コンテキストから参照される。`cb_tx1` は INT1 ISR（`OUT_05_CONOUT` → `x_enqueue`）と Timer0 ISR（`Transmit_TX1_Buf` → `x_dequeue`）から参照される。

`volatile` がないため、コンパイラが `count` をレジスタにキャッシュし、ISR からの更新が反映されない可能性がある。

## 修正内容
```c
// Before
int head;
int tail;
int count;

// After
volatile int head;
volatile int tail;
volatile int count;
```

## 影響
- コンパイラ最適化条件下で、Z80 へのバッファステータス報告が正確になる

## Phase 1 / Step 4

Ref: BugFixPlan.md