### PR TITLE
BUG #5 [LOW]: Transmit_TX1_Buf() に z80_int_num_tx1 < 128 ガードを追加

### DIFF
--- a/avr/src/emuldev/em_consoleio.c
+++ b/avr/src/emuldev/em_consoleio.c
@@ -60,9 +60,10 @@ void Transmit_TX1_Buf(void)
 	if (data != '\0') {
 		USART1_Transmit(data);
 //		x_printf("%d %d %d\n", cb_tx1.count, cb_tx1.head, cb_tx1.tail);
-		if (cb_tx1.count == 0 ||
-		    cb_tx1.count == cb_tx1.size / 4 ||
-		    cb_tx1.count == cb_tx1.size / 2) {
+		if (z80_int_num_tx1 < 128 &&
+		    (cb_tx1.count == 0 ||
+		     cb_tx1.count == cb_tx1.size / 4 ||
+		     cb_tx1.count == cb_tx1.size / 2)) {
 			Z80_EXTINT_low(z80_int_num_tx1 << 1);			
 		}
 	}


### PR DESCRIPTION
# BUG #5: `Transmit_TX1_Buf()` に `z80_int_num_tx1 < 128` ガードがない

## 重大度: LOW

## 問題
`Enqueue_RX1_Buf()` には `z80_int_num_rx1 < 128` のガードがあるが、`Transmit_TX1_Buf()` にはない。初期化前（`z80_int_num_tx1 = 128`）に呼ばれた場合、不正なベクタ値で `Z80_EXTINT_low()` が呼ばれるリスクがある。

## 修正内容
`Z80_EXTINT_low()` 呼び出し前に `z80_int_num_tx1 < 128` ガードを追加。

## 影響
- 初期化前の意図しない割り込み送信を防止
- BOOT 後は `z80_int_num_tx1 = 2` のため通常動作に変化なし
- 設計の一貫性を確保

## Phase 1 / Step 5
**注意**: Step 7 (PR #25) および Step 8 (PR #26) も同一関数 `Transmit_TX1_Buf()` を修正するため、すべて適用する場合は統合コードを確認すること。

Ref: BugFixPlan.md