### PR TITLE
BUG #12 [MODERATE]: Enqueue_RX1_Buf() の戻り値チェック追加と RX バッファ拡大

### DIFF
--- a/avr/src/emuldev/em_consoleio.c
+++ b/avr/src/emuldev/em_consoleio.c
@@ -11,7 +11,7 @@
 //=================================================================
 // Console I/O emulated device
 //=================================================================
-#define RX1_BUF_SIZE	8
+#define RX1_BUF_SIZE	64
 #define TX1_BUF_SIZE	128
 static char rx1_buf[RX1_BUF_SIZE];
 static char tx1_buf[TX1_BUF_SIZE];
@@ -41,9 +41,9 @@ void init_em_console(void)
 void Enqueue_RX1_Buf()
 {
 	while (UCSR1A & _BV(RXC1)) {
-		x_enqueue(&cb_rx1, UDR1);
+		int st = x_enqueue(&cb_rx1, UDR1);
 		// Notify Z80 if interrupt setting is enable
-		if (z80_int_num_rx1 < 128) {
+		if (st != 3 && z80_int_num_rx1 < 128) {
 			// CAUTION: vector is NOT interrupt number(0-127)
 			Z80_EXTINT_low(z80_int_num_rx1 << 1);
 		}


### PR DESCRIPTION
# BUG #12: `Enqueue_RX1_Buf()` バッファ満杯時のデータロストと偽割り込み

## 重大度: MODERATE

## 問題

`cb_rx1` が満杯（8 バイト）のとき、`x_enqueue()` は 3 を返してデータを破棄するが、戻り値がチェックされず `Z80_EXTINT_low()` が呼ばれていた。新規データがバッファに入っていないのに偽の割り込み通知が Z80 に送られ、PR #19 のレース窓を広げていた。

## 修正内容
1. `x_enqueue()` の戻り値を確認し、バッファ満杯（return 3）時は Z80 への割り込み通知を抑止
2. `RX1_BUF_SIZE` を 8 → 64 バイトに拡大し、バッファ溢れ自体の発生頻度を低減（SRAM +56 バイト）

```c
// Before
x_enqueue(&cb_rx1, UDR1);\n
if (z80_int_num_rx1 < 128) {
    Z80_EXTINT_low(z80_int_num_rx1 << 1);
}

// After
int st = x_enqueue(&cb_rx1, UDR1);
if (st != 3 && z80_int_num_rx1 < 128) {
    Z80_EXTINT_low(z80_int_num_rx1 << 1);
}
```

## 影響
- 偽割り込みによる PR #19 レース窓拡大を防止
- 高速ペースト操作での文字ロスト発生頻度を低減

## Phase 1 / Step 6

Ref: BugFixPlan.md