### PR TITLE
BUG #14 [LOW]: Transmit_TX1_Buf() の非ブロッキング化

### DIFF
--- a/avr/src/emuldev/em_consoleio.c
+++ b/avr/src/emuldev/em_consoleio.c
@@ -56,9 +56,12 @@ void Enqueue_RX1_Buf()
 ///////////////////////////////////////////////////////////////////
 void Transmit_TX1_Buf(void)
 {
+	// Skip if UART TX is busy (non-blocking)
+	if (!(UCSR1A & _BV(UDRE1))) return;
+
 	char data = x_dequeue(&cb_tx1);
 	if (data != '\0') {
-		USART1_Transmit(data);
+		UDR1 = data;	// UDRE1 already checked, write directly
 //		x_printf("%d %d %d\n", cb_tx1.count, cb_tx1.head, cb_tx1.tail);
 		if (cb_tx1.count == 0 ||
 		    cb_tx1.count == cb_tx1.size / 4 ||


### PR DESCRIPTION
# BUG #14: `USART1_Transmit()` の Timer0 ISR 内ビジーウェイト

## 重大度: LOW

## 問題
`Transmit_TX1_Buf()` は Timer0 ISR（1ms 周期、通常 ISR）から呼ばれ、`USART1_Transmit()` 内の `while (!(UCSR1A & _BV(UDRE1)))` ビジーウェイトにより全割り込みがブロックされる。9600 bps では約 52 文字に 1 回、~40µs のブロックが発生する。

## 修正内容
`UDRE1` フラグを事前チェックし、TX ビジーなら送信をスキップして次の Timer0 サイクルに持ち越す。`UDR1` への直接書き込みにより `USART1_Transmit()` を介さない。

```c
// Before\nchar data = x_dequeue(&cb_tx1);
if (data != '\\0') {
    USART1_Transmit(data);

// After
if (!(UCSR1A & _BV(UDRE1))) return;
char data = x_dequeue(&cb_tx1);
if (data != '\\0') {
    UDR1 = data;
```

## スループットへの影響
| ボーレート | 修正前 | 修正後 | 備考 |
|-----------|--------|--------|------|
| 9600 bps | ~960 chars/sec | ~940 chars/sec | ~52 文字に 1 回スキップ |
| 19200 bps | ~1000 chars/sec | ~1000 chars/sec | 変化なし |

## Phase 1 / Step 7
**注意**: Step 5 (PR #23 ) および Step 8 (PR #26 )も同一関数 `Transmit_TX1_Buf()` を修正するため、すべて適用する場合は統合コードを確認すること。

Ref: BugFixPlan.md