### PR TITLE
BUG #15 [LOW]: CONOUT フロー制御の閾値ギャップ修正

### DIFF
--- a/avr/src/emuldev/em_consoleio.c
+++ b/avr/src/emuldev/em_consoleio.c
@@ -62,7 +62,7 @@ void Transmit_TX1_Buf(void)
 //		x_printf("%d %d %d\n", cb_tx1.count, cb_tx1.head, cb_tx1.tail);
 		if (cb_tx1.count == 0 ||
 		    cb_tx1.count == cb_tx1.size / 4 ||
-		    cb_tx1.count == cb_tx1.size / 2) {
+		    cb_tx1.count == cb_tx1.size / 2 - 1) {
 			Z80_EXTINT_low(z80_int_num_tx1 << 1);			
 		}
 	}


### PR DESCRIPTION
# BUG #15: CONOUT フロー制御の閾値ギャップ

## 重大度: LOW\n\n

## 問題

Z80 CONOUT は `count >= 64` で送信待ちに入るが、AVR の通知は `count` が**ちょうど** 0, 32, 64 に一致したときのみ送られる。Z80 が `count = 64` を読み取り待機に入った場合、`count` が 32 に到達するまで通知を受けられず、最大 32ms（9600 bps）の不要な待ちが発生する。

## 修正内容

```c
// Before
cb_tx1.count == cb_tx1.size / 2    // 64

// After\ncb_tx1.count == cb_tx1.size / 2 - 1  // 63
```

Z80 の待機閾値（`count >= 64`）を下回った最初の瞬間（63）で通知を送る。

## 影響
- バースト出力（DIR, TYPE 等）時のスループット改善\n- インタラクティブ操作（1 文字エコー）では影響軽微

## Phase 1 / Step 8

**注意**: Step 5 (PR #23) および Step 7 (PR #25) も同一関数 `Transmit_TX1_Buf()` を修正するため、すべて適用する場合は統合コードを確認すること。

Ref: BugFixPlan.md