### PR TITLE
BUG #6 [CRITICAL]: LOAD_CCP_BDOS にリジェクション・リトライを追加

### DIFF
--- a/z80/cpm22/bios/bios.asm
+++ b/z80/cpm22/bios/bios.asm
@@ -339,7 +339,10 @@ LOAD_CCP_BDOS:
         OUT (C), L
 
         ; Load CPP+BDOS
+LOAD_RETRY:
         CALL DISK_READ_SUB
+        CP 4
+        JR Z, LOAD_RETRY               ; retry if rejected
         OR A
         RET Z                           ; Success
 


### PR DESCRIPTION
# BUG #6: `LOAD_CCP_BDOS` にリジェクション・リトライがない

## 重大度: CRITICAL

## 問題

通常の READ パス (`RETRY_READ`) では `CP 4` によりリジェクト(4)をリトライするが、`LOAD_CCP_BDOS` では `OR A` で非ゼロをすべてエラーとして `BOOT_ERROR_HALT` に到達する。

WBOOT 時に AVR 側で WRITE が進行中の場合、READ がリジェクトされるとシステムが HALT する。

## 修正内容

```asm
; Before
        CALL DISK_READ_SUB
        OR A
        RET Z                            ; Success

; After
LOAD_RETRY:
        CALL DISK_READ_SUB
        CP 4
        JR Z, LOAD_RETRY               ; retry if rejected
        OR A
        RET Z                            ; Success
```

## 影響
- WBOOT 時のリジェクト発生による HALT を防止
- #30 → #32 → #27 の障害連鎖を断つ最後の防衛線

## Phase 1 / Step 9

Ref: BugFixPlan.md