### PR TITLE
BUG #8 [IMPORTANT]: Timer2 ISR に再入ガードを追加

### DIFF
--- a/avr/src/isr.c
+++ b/avr/src/isr.c
@@ -9,6 +9,7 @@
 #include "z80io.h"
 #include "emuldev/emuldev.h"
 #include "fatfs/diskio.h"
+#include <stdbool.h>
 
 //
 // External Interrupt
@@ -104,8 +105,14 @@ ISR(TIMER0_COMP_vect)
 ///////////////////////////////////////////////////////////////////
 ISR(TIMER2_COMP_vect, ISR_NOBLOCK)
 {
+	static volatile bool in_progress = false;
 	disk_timerproc();
+	if (in_progress) return;
+	in_progress = true;
+
 	em_disk_read();
 	em_disk_write();
 	em_led_heartbeat(2);			// Blink RED LED at 2Hz
+
+	in_progress = false;
 }


### PR DESCRIPTION
# BUG #8: Timer2 ISR (`ISR_NOBLOCK`) の再入リスク

## 重大度: IMPORTANT

## 問題

`ISR_NOBLOCK` により ISR 突入直後に `sei()` が挿入される。SD カード操作が 10ms 以上かかると次の Timer2 割り込みで再入が発生する。状態マシンにより二重処理は抑止されるが、ISR ネストによるスタック消費が蓄積し、ATmega128 の 4KB SRAM でスタックオーバーフローのリスクがある。

## 修正内容

`static volatile bool` ガードで再入を検知し、既に実行中なら `em_disk_read()`/`em_disk_write()`/`em_led_heartbeat()` をスキップする。`disk_timerproc()` はガードの外に配置し、FatFs のタイマ精度を維持する。

```c
ISR(TIMER2_COMP_vect, ISR_NOBLOCK)
{
    static volatile bool in_progress = false;
    disk_timerproc();
    if (in_progress) return;
    in_progress = true;

    em_disk_read();
    em_disk_write();
    em_led_heartbeat(2);

    in_progress = false;
}
```

## 影響
- スタックオーバーフロー防止
- #31（デッドロック）修正の前提条件

## Phase 1 / Step 10

Ref: BugFixPlan.md