### PR TITLE
BUG #9 [IMPORTANT]: DEBUGGER の EI コメント解除

### DIFF
--- a/z80/cpm22/bios/bios.asm
+++ b/z80/cpm22/bios/bios.asm
@@ -120,7 +120,7 @@ DEBUGGER:
         EXX
 
         LD SP, (SP_ADR)         ; Restore SP
-;        EI
+        EI
         HALT                    ; Wait for INT 4
         RET                     ; Resume
 


### PR DESCRIPTION
# BUG #9: DEBUGGER の HALT が DI 状態で実行される

## 重大度: IMPORTANT

## 問題

DEBUGGER ハンドラで `EI` がコメントアウトされているため、Z80 が DI 状態で HALT に入り、INT による HALT 解除が不可能。`dbg_Continue()` が `Z80_EXTINT_low()` で INT を送っても Z80 に届かず、NMI またはリセットでしか復帰できない。

## 修正内容

```asm
; Before
        LD SP, (SP_ADR)         ; Restore SP
;        EI
        HALT                    ; Wait for INT 4

; After
        LD SP, (SP_ADR)         ; Restore SP
        EI
        HALT                    ; Wait for INT 4
```

## 影響
- デバッガの continue 機能が正常に動作するようになる

## Phase 1 / Step 11

Ref: BugFixPlan.md