### PR TITLE
BUG #1: 割り込みベクタの FIFO キュー化

### DIFF
--- a/avr/src/emuldev/em_consoleio.c
+++ b/avr/src/emuldev/em_consoleio.c
@@ -45,7 +45,7 @@ void Enqueue_RX1_Buf()
 		// Notify Z80 if interrupt setting is enable
 		if (z80_int_num_rx1 < 128) {
 			// CAUTION: vector is NOT interrupt number(0-127)
-			Z80_EXTINT_low(z80_int_num_rx1 << 1);
+			Z80_EXTINT_enqueue(z80_int_num_rx1 << 1);
 		}
 	}
 }
@@ -63,7 +63,7 @@ void Transmit_TX1_Buf(void)
 		if (cb_tx1.count == 0 ||
 		    cb_tx1.count == cb_tx1.size / 4 ||
 		    cb_tx1.count == cb_tx1.size / 2) {
-			Z80_EXTINT_low(z80_int_num_tx1 << 1);			
+			Z80_EXTINT_enqueue(z80_int_num_tx1 << 1);			
 		}
 	}
 }

--- a/avr/src/emuldev/em_diskio.c
+++ b/avr/src/emuldev/em_diskio.c
@@ -286,7 +286,7 @@ void em_disk_write(void)
 		cfd->write.state = REJECTED;
 		if (int_level_write < 128) {
 			// CAUTION: vector is NOT interrupt number(0-127)
-			Z80_EXTINT_low(int_level_write << 1);
+			Z80_EXTINT_enqueue(int_level_write << 1);
 		}
 		return;
 	}
@@ -457,7 +457,7 @@ error_skip:
 #endif
 	if (int_level_write < 128) {
 		// CAUTION: vector is NOT interrupt number(0-127)
-		Z80_EXTINT_low(int_level_write << 1);
+		Z80_EXTINT_enqueue(int_level_write << 1);
 	}
 	cfd->write.state = IDLE;	
 }
@@ -537,7 +537,7 @@ void em_disk_read(void)
 		cfd->read.state = REJECTED;
 		if (int_level_read < 128) {
 			// CAUTION: vector is NOT interrupt number(0-127)
-			Z80_EXTINT_low(int_level_read << 1);
+			Z80_EXTINT_enqueue(int_level_read << 1);
 		}
 		return;
 	}
@@ -587,7 +587,7 @@ error_skip:
 #endif
 	if (int_level_read < 128) {
 		// CAUTION: vector is NOT interrupt number(0-127)
-		Z80_EXTINT_low(int_level_read << 1);
+		Z80_EXTINT_enqueue(int_level_read << 1);
 	}
 	cfd->read.state = IDLE;
 }

--- a/avr/src/isr.c
+++ b/avr/src/isr.c
@@ -67,10 +67,13 @@ ISR(INT1_vect)
 ///////////////////////////////////////////////////////////////////
 ISR(INT4_vect)
 {
+	// Dequeue current vector from queue
+	uint8_t vector = z80_int_vector;
+
 	// Z80 /INT = High
 	Z80_EXTINT_High();
 	// Z80 int vector
-	PORTA = z80_int_vector;
+	PORTA = vector;
 	DDRA  = 0xff;
 
 	// Clear /WAIT (instead of Z80_CLRWAIT())
@@ -81,6 +84,11 @@ ISR(INT4_vect)
 	PORTA = 0xff;					// 1 CLK Set PortA input and High-Z
 	DDRA  = 0x00;					// 1 CLK
 	SET_BIT(PORTD, PORTD5);			// 2 CLK
+
+	// Consume from queue and re-assert /INT if more entries remain
+	if (Z80_EXTINT_dequeue()) {
+		CLR_BIT(PORTD, PORTD4);		// /INT = Low for next vector
+	}
 }
 
 ///////////////////////////////////////////////////////////////////

--- a/avr/src/z80io.c
+++ b/avr/src/z80io.c
@@ -135,6 +135,15 @@ void Z80_RESET_GO(uint8_t *adr)
 //
 
 volatile uint8_t z80_int_vector;
+
+//
+// Interrupt vector FIFO queue
+//
+#define INT_QUEUE_SIZE 8
+static volatile uint8_t int_queue[INT_QUEUE_SIZE];
+static volatile uint8_t int_queue_head = 0;
+static volatile uint8_t int_queue_tail = 0;
+
 void Z80_EXTINT_low(uint8_t vector)
 {
 	z80_int_vector = vector;
@@ -144,6 +153,37 @@ void Z80_EXTINT_low(uint8_t vector)
 void Z80_EXTINT_High(void)
 {
 	SET_BIT(PORTD, PORTD4);		// /INT = High
+}
+
+void Z80_EXTINT_enqueue(uint8_t vector)
+{
+	uint8_t sreg = SREG;
+	cli();
+	uint8_t next = (int_queue_tail + 1) % INT_QUEUE_SIZE;
+	if (next != int_queue_head) {
+		int_queue[int_queue_tail] = vector;
+		int_queue_tail = next;
+	}
+	// Assert /INT only when queue transitions from empty (count == 1)
+	uint8_t count = (int_queue_tail - int_queue_head + INT_QUEUE_SIZE) % INT_QUEUE_SIZE;
+	if (count == 1) {
+		z80_int_vector = vector;
+		CLR_BIT(PORTD, PORTD4);		// /INT = Low
+	}
+	SREG = sreg;
+}
+
+uint8_t Z80_EXTINT_dequeue(void)
+{
+	if (int_queue_head == int_queue_tail) {
+		return 0;	// queue empty
+	}
+	int_queue_head = (int_queue_head + 1) % INT_QUEUE_SIZE;
+	if (int_queue_head != int_queue_tail) {
+		z80_int_vector = int_queue[int_queue_head];
+		return 1;	// more entries remain
+	}
+	return 0;	// queue now empty
 }
 
 void Z80_EXTINT(uint8_t vector)

--- a/avr/src/z80io.h
+++ b/avr/src/z80io.h
@@ -23,6 +23,8 @@ extern void Z80_RESET(void);
 extern void Z80_NMI(void);
 extern void Z80_EXTINT(uint8_t vector);
 extern void Z80_EXTINT_low(uint8_t vector);
+extern void Z80_EXTINT_enqueue(uint8_t vector);
+extern uint8_t Z80_EXTINT_dequeue(void);
 extern void Z80_EXTINT_High(void);
 extern void Z80_CLRWAIT(void);
 extern void Z80_HALT(void);


### PR DESCRIPTION
# BUG #1: `z80_int_vector` のキュー化（Step 12）

## 概要
割り込みベクタを単一グローバル変数からFIFOキュー（リングバッファ）に変更し、複数ISRからの割り込みベクタ上書き問題（根本原因）を解消する。

## 問題
`Z80_EXTINT_low()` が `/INT=Low` にした後、Z80 が INTA サイクルを開始するまでの 2〜8µs の間に別の ISR（Timer0, USART1_RX等）が割り込むと、`z80_int_vector` が上書きされる。`/INT` は既に Low のため 2回目の `CLR_BIT` では Z80 側に変化が通知されず、上書き前のベクタに対応する割り込みが消失する。

ディスク I/O 完了通知（INT 0）が消失すると、Z80 の `WAIT_READ_COMPLETE` / `WAIT_WRITE_COMPLETE` が永久にブロックし、システムがハング。

## 修正内容

### z80io.c
- 8エントリのリングバッファ型 FIFO キューを追加
- `Z80_EXTINT_enqueue()`: ベクタをキューに追加し、キューが空→非空に遷移した場合のみ `/INT=Low` をアサート（SREG保存/cli()で排他制御）
- `Z80_EXTINT_dequeue()`: キューから消費し、残りがあれば `z80_int_vector` を次のエントリに更新

### z80io.h
- `Z80_EXTINT_enqueue()`, `Z80_EXTINT_dequeue()` の宣言追加

### isr.c — ISR(INT4_vect)
- ベクタ消費後にキューの残りを確認し、あれば再度 `/INT=Low` をアサート
- Z80 は EI + RETI 後に次の割り込みを受理する

### em_consoleio.c（2箇所）
- `Enqueue_RX1_Buf()`: `Z80_EXTINT_low()` → `Z80_EXTINT_enqueue()`
- `Transmit_TX1_Buf()`: `Z80_EXTINT_low()` → `Z80_EXTINT_enqueue()`

### em_diskio.c（4箇所）
- `em_disk_write()` REJECTED通知: `Z80_EXTINT_low()` → `Z80_EXTINT_enqueue()`
- `em_disk_write()` 完了通知: `Z80_EXTINT_low()` → `Z80_EXTINT_enqueue()`
- `em_disk_read()` REJECTED通知: `Z80_EXTINT_low()` → `Z80_EXTINT_enqueue()`
- `em_disk_read()` 完了通知: `Z80_EXTINT_low()` → `Z80_EXTINT_enqueue()`

### 変更なし
- `em_debugger.c` の `dbg_Continue()`: デバッガは即時送信が必要なため `Z80_EXTINT_low()` を維持
- `Z80_EXTINT()`: パルス送信用（delay + High）、用途が異なるため維持

## Phase
Phase 2 — 根本原因の修正（Step 12）

## 関連BUG
PR #30（Severity: Critical — Zork I 長時間プレイ中のハングの直接原因）