### PR TITLE
BUG #2: cli()/ExtMem_attach() の順序修正

### DIFF
--- a/avr/src/emuldev/em_diskio.c
+++ b/avr/src/emuldev/em_diskio.c
@@ -336,11 +336,12 @@ void em_disk_write(void)
 		} else {
 			plen = sizeof(tmpbuf) - offset;			
 		}
-		cli();
 		ExtMem_attach();
+		uint8_t sreg1 = SREG;
+		cli();
 		memcpy(&tmpbuf[offset], src, plen);
+		SREG = sreg1;
 		ExtMem_detach();
-		sei();
 		// write
 #if DEBUG_PRINT_WR
 		x_printf("Write\n");
@@ -373,11 +374,12 @@ void em_disk_write(void)
 #if DEBUG_PRINT_WR
 		x_printf("$$$ %d/%d\n", i, n);
 #endif
-		cli();
 		ExtMem_attach();
+		uint8_t sreg2 = SREG;
+		cli();
 		memcpy(tmpbuf, src, sizeof(tmpbuf));
+		SREG = sreg2;
 		ExtMem_detach();
-		sei();
 		if ((cfd->write.result = f_write(&cfd->fil, tmpbuf, sizeof(tmpbuf), &bytes)) != FR_OK) {
 			goto error_skip;
 		}
@@ -422,11 +424,12 @@ void em_disk_write(void)
 #if DEBUG_PRINT_WR
 		x_printf("Modify/");
 #endif
-		cli();
 		ExtMem_attach();
+		uint8_t sreg3 = SREG;
+		cli();
 		memcpy(tmpbuf, src, len);
+		SREG = sreg3;
 		ExtMem_detach();
-		sei();
 		// write
 #if DEBUG_PRINT_WR
 		x_printf("Write\n");
@@ -561,22 +564,24 @@ void em_disk_read(void)
 		if (cfd->read.result != FR_OK) {
 			goto error_skip;
 		}
-		cli();
 		ExtMem_attach();
+		uint8_t sreg4 = SREG;
+		cli();
 		memcpy(dst, tmpbuf, sizeof(tmpbuf));
+		SREG = sreg4;
 		ExtMem_detach();
-		sei();
 		dst = (uint8_t*)dst + sizeof(tmpbuf);
 	}
 	len = len % sizeof(tmpbuf);
 	if (len > 0) {
 		cfd->read.result = f_read(&cfd->fil, tmpbuf, len, &br);
 		if (cfd->read.result == FR_OK) {
-			cli();
 			ExtMem_attach();
+			uint8_t sreg5 = SREG;
+			cli();
 			memcpy(dst, tmpbuf, len);
+			SREG = sreg5;
 			ExtMem_detach();
-			sei();
 		}
 	}
 	


### PR DESCRIPTION
# BUG #2: `cli()` / `ExtMem_attach()` の順序修正（Step 13）

## 概要
`em_diskio.c` の `em_disk_read()` / `em_disk_write()` 内で、`cli()` が `ExtMem_attach()` よりも先に呼ばれていた問題を修正。

## 問題
`cli()` で割り込みを無効にした後に `ExtMem_attach()` → `Z80_BUSREQ(1)` を呼ぶと、バス取得待ち中に Z80 の I/O割り込み（INT0/INT1）が処理されない。Z80 が I/O WAIT 状態（IN/OUT命令でAVRの応答待ち）の場合、INT0/INT1 が処理されないため Z80 がバスを解放できず、BUSACK が返らずデッドロックする可能性がある。

## 修正内容

全5箇所に同じパターンを適用：

**修正前:**
```c
cli();
ExtMem_attach();
memcpy(dst, tmpbuf, sizeof(tmpbuf));
ExtMem_detach();
sei();
```

**修正後:**
```c
ExtMem_attach();           // 割り込み有効のままバスを取得
uint8_t sreg = SREG;
cli();
memcpy(dst, tmpbuf, sizeof(tmpbuf));
SREG = sreg;               // SREG復元（sei()の代わり）
ExtMem_detach();
```

### 適用箇所（5箇所）
| 関数 | 処理内容 |
|------|----------|
| `em_disk_write()` | 先頭未アライン書き込み |
| `em_disk_write()` | アライン済みブロック書き込み |
| `em_disk_write()` | 末尾未アライン書き込み |
| `em_disk_read()` | アライン済みブロック読み出し |
| `em_disk_read()` | 端数読み出し |

## 前提
Step 10（PR #28: Timer2再入ガード）が適用済みであれば、Timer2 ISR 再入によるバス操作の二重実行は発生しない。

## Phase
Phase 2 — 根本原因の修正（Step 13）

## 関連BUG
PR #31（Severity: High — BUSREQ中のデッドロック）