### PR TITLE
BUG #7: SELDSK デバッグアサーション追加（暫定修正）

### DIFF
--- a/avr/src/emuldev/em_diskio.c
+++ b/avr/src/emuldev/em_diskio.c
@@ -101,6 +101,12 @@ void OUT_0A_DSK_SelectDisk(uint8_t data)
 #endif
 	if (data < MAX_FILES) {
 		cfd = &fd[data];
+#if DEBUG_PRINT_STATE
+		if (cfd->read.state == DOING || cfd->write.state == DOING) {
+			x_printf("!!! SELDSK while I/O active: rd=%d wr=%d\n",
+			         cfd->read.state, cfd->write.state);
+		}
+#endif
 		// Re-open if previous operation was failure.
 		if (cfd->open_result  != FR_OK ||
 		    cfd->write.result != FR_OK ||


### PR DESCRIPTION
# BUG #7: SELDSK の安全な状態リセット — 暫定修正（Step 14）

## 概要
`OUT_0A_DSK_SelectDisk()` にデバッグ用アサーションを追加し、SELDSK がディスク I/O 実行中（DOING 状態）に呼ばれるケースが発生するかを観測する。

## 背景
BIOS の `SELDSK` は `WRITE_FLUSH` 完了後に `OUT (PORT_SELDSK)` を発行するため、正常フローでは WRITE が DOING 状態で `OUT_0A_DSK_SelectDisk()` に到達することはない。この問題が顕在化するのは PR #30 割り込みベクタ消失やPR #28 Timer2 再入が原因で完了通知が失われた場合に限定される。

PR #30 と PR #28 の修正により発生頻度は大幅に低下するため、まずは観測用のデバッグ出力を追加し、修正の必要性を再評価する。

## 修正内容
```c
#if DEBUG_PRINT_STATE
    if (cfd->read.state == DOING || cfd->write.state == DOING) {
        x_printf("!!! SELDSK while I/O active: rd=%d wr=%d\n",
                 cfd->read.state, cfd->write.state);
    }
#endif
```

- `DEBUG_PRINT_STATE`（デフォルト: 0）を 1 に設定すると有効化
- 通常ビルドではコード生成なし（ゼロコスト）

## Phase
Phase 3 — 設計レベルの改善（Step 14）

## 関連BUG
PR #32（Severity: Medium — BUG #1, BUG #8 修正後に再評価）

## 前提PR
- PR #30:  割り込みベクタ FIFO キュー化
- PR #28:  Timer2 再入ガード