### PR TITLE
fix: force LF line endings for diskdefs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.patch    text eol=crlf
+z80/cpm22/image/diskdefs text eol=lf


### PR DESCRIPTION
## 概要

Fixes #33

## 変更内容

`.gitattributes` に以下を追加し、`z80/cpm22/image/diskdefs` の改行コードを LF に強制する。

```
z80/cpm22/image/diskdefs text eol=lf
```

## 問題

Windows 環境でクローン/チェックアウト時に `diskdefs` の改行コードが CRLF になると、`mkfs.cpm` が `os 2.2\r` と解釈して以下のエラーが発生する。

```
' in line 9nvalid OS type `2.2
make: *** [Makefile:41: DISK00.IMG] Error 1
```

## 対応

`.gitattributes` でパス指定により `diskdefs` のみ `eol=lf` を強制する。